### PR TITLE
Remove unnecessary things in README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,24 +51,4 @@ Use Jenkins to automate your development workflow, so you can focus on work that
 
 Execute repetitive tasks, save time, and optimize your development process with Jenkins.
 
-# Downloads
-
-The Jenkins project provides official distributions as WAR files, Docker images, native packages and installers for platforms including several Linux distributions and Windows.
-See the [Downloads](https://www.jenkins.io/download) page for references.
-
-For all distributions Jenkins offers two release lines:
-
-- [Weekly](https://www.jenkins.io/download/weekly/) -
-  Frequent releases which include all new features, improvements, and bug fixes.
-- [Long-Term Support (LTS)](https://www.jenkins.io/download/lts/) -
-  Older release line which gets periodically updated via bug fix backports.
-
-Latest releases:
-[![Jenkins Regular Release](https://img.shields.io/endpoint?url=https%3A%2F%2Fwww.jenkins.io%2Fchangelog%2Fbadge.json)](https://www.jenkins.io/changelog)
-[![Jenkins LTS Release](https://img.shields.io/endpoint?url=https%3A%2F%2Fwww.jenkins.io%2Fchangelog-stable%2Fbadge.json)](https://www.jenkins.io/changelog-stable)
-
-# Source
-
-Our latest and greatest source of Jenkins can be found on [GitHub](https://github.com/jenkinsci/jenkins). Fork us!
-
 


### PR DESCRIPTION
Removed Downloads section and Source 
- this is not needed in Weekend Challenge Alert: Master Jenkins Step by Step! 
- this Downloads section and Source is redirecting jenkins website not out repo. 